### PR TITLE
Switch from obsolete nats-io/nats to maintained nats-io/go-nats

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,48 +1,41 @@
-hash: cc16885b3b3777c7d1db305f84a71049b608f5f4797e8b7388691bdf7b16ef9c
-updated: 2017-07-05T13:30:45.711479926-07:00
+hash: 34f7365e0186842de7bc508481cc9a6e14e3abbee946436edc0ef3164f23219e
+updated: 2018-01-09T07:47:55.427137794+02:00
 imports:
-- name: github.com/nats-io/gnatsd
-  version: 6a0830fbdc523a05f9564f5f3f46a4000b8d122c
+- name: github.com/nats-io/go-nats
+  version: d66cb54e6b7bdd93f0b28afc8450d84c780dfb68
   subpackages:
-  - server
-  - test
-  - conf
-  - logger
-  - server/pse
-  - util
-- name: github.com/nats-io/nats
-  version: 61923ed1eaf8398000991fbbee2ef11ab5a5be0d
-  subpackages:
-  - test
   - encoders/builtin
   - util
 - name: github.com/nats-io/nuid
-  version: 3cf34f9fca4e88afa9da8eabd75e3326c9941b44
+  version: 33c603157d6fd1b0ac2599bcc4a286b36479a06d
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
   subpackages:
   - hooks/test
-- name: golang.org/x/crypto
-  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
-  repo: https://go.googlesource.com/crypto
-  subpackages:
-  - bcrypt
-  - blowfish
 - name: golang.org/x/sys
   version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
   subpackages:
   - unix
-  - windows/svc
-  - windows/svc/debug
-  - windows/svc/mgr
-  - windows/svc/eventlog
   - windows
   - windows/registry
+  - windows/svc
+  - windows/svc/debug
+  - windows/svc/eventlog
+  - windows/svc/mgr
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/nats-io/gnatsd
+  version: ee7b97e6ee3068900d39f1fe4ae7b75f358416ab
+  subpackages:
+  - conf
+  - logger
+  - server
+  - server/pse
+  - test
+  - util
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -51,3 +44,9 @@ testImports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+- name: golang.org/x/crypto
+  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
+  repo: https://go.googlesource.com/crypto
+  subpackages:
+  - bcrypt
+  - blowfish

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/rybit/nats_logrus_hook
 import:
-- package: github.com/nats-io/nats
-  version: v1.2.2
+- package: github.com/nats-io/go-nats
+  version: v1.4.0
 - package: github.com/sirupsen/logrus
   version: v1.0.0
 testImport:

--- a/nats.go
+++ b/nats.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nats_logrus_hook.go
+++ b/nats_logrus_hook.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/nats-io/nats"
+	"github.com/nats-io/go-nats"
 	"github.com/sirupsen/logrus"
 )
 

--- a/nats_logrus_hook_test.go
+++ b/nats_logrus_hook_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/nats"
-	"github.com/nats-io/nats/test"
+	"github.com/nats-io/go-nats"
+	"github.com/nats-io/gnatsd/test"
 	"github.com/sirupsen/logrus"
 	ltest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This fixes namespace incompatibility due to package refactoring `nats-io/nats` -> `nats-io/go-nats` + `nats-io/gnatsd` (which has server code)